### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 使用kind安装k8s集群：
 
 ```bash
-$ kind create cluster --config=kind/kind-config.yaml --name=kubeflow --image=kindest/node:v1.16.9
+$ kind create cluster --config=kind/kind-config.yaml --name=kubeflow --image=kindest/node:v1.16.15
 ```
 
 启动成功后可以看到开了一个30000端口：


### PR DESCRIPTION
update kindest/node version 1.16.9 -> 1.16.15.
we use kindest/node:1.16.9 can't start k8s cluster.